### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/Adapter.js
+++ b/lib/Adapter.js
@@ -7,7 +7,7 @@
 var redis = require("redis");
 var fs = require('fs');
 var nutil = require("util");
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var newSwarmPhase = require("./SwarmingPhase.js").newSwarmPhase;
 var swarmDSL = require("./SwarmDSL.js");
 

--- a/lib/GenericOutlet.js
+++ b/lib/GenericOutlet.js
@@ -11,7 +11,7 @@
 */
 
 var redis = require("redis");
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var dslUtil = require("./SwarmDSL.js");
 var newSwarmPhase = require("./SwarmingPhase.js").newSwarmPhase;
 

--- a/lib/SwarmCore.js
+++ b/lib/SwarmCore.js
@@ -16,7 +16,7 @@ exports.runStandardAdapter = function (name){
 
 exports.createAdapter = exports.adapter.init;
 var fs = require("fs");
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 require('./errorCodes.js');
 
 

--- a/nodeClient/NodeClient.js
+++ b/nodeClient/NodeClient.js
@@ -16,7 +16,7 @@ make swarmHub global variable available (for the last client open only, usually 
 require("./SwarmHub.js");
 var tcpUtil = require("../lib/TCPSockUtil.js");
 var debug   = require("../lib/SwarmDebug.js");
-var uuid    = require('node-uuid');
+var uuid    = require('uuid');
 thisAdapter.nodeName = "Client";
 
 var net = require("net");

--- a/package.json
+++ b/package.json
@@ -41,33 +41,31 @@
       "url": "http://www.gnu.org/licenses/lgpl.html"
     }
   ],
-  "dependencies" : {
-    "q"               : "=1.2.0"  ,
-    "asynchron"       : ">=1.0.10",
-    "apersistence"    : ">=1.0.4",
-    "double-check"    : ">=0.1.5",
-    "acl-magic"       : ">=1.0.9",
-    "clone"           : ">=0.1.8",
-    "MD5"             : ">=1.2.0",
-    "nodemailer"      : ">=0.5.2",
-    "node-uuid"       : ">=1.4.0",
-    "redis"           : "0.12.1",
-    "socket.io"       : ">=1.2.1",
-    "limiter2"        : ">=1.1.0",
-    "request"         : ">=2.53.0",
-    "tmp"             : ">=0.0.24",
-    "commander"       : ">=2.8.1",
-    "pubsubshare"     : ">=0.6.0",
-    "https-auto"      : ">=0.5.5",
-    "safebox"         : ">=0.2.1"
+  "dependencies": {
+    "MD5": ">=1.2.0",
+    "acl-magic": ">=1.0.9",
+    "apersistence": ">=1.0.4",
+    "asynchron": ">=1.0.10",
+    "clone": ">=0.1.8",
+    "commander": ">=2.8.1",
+    "double-check": ">=0.1.5",
+    "https-auto": ">=0.5.5",
+    "limiter2": ">=1.1.0",
+    "nodemailer": ">=0.5.2",
+    "pubsubshare": ">=0.6.0",
+    "q": "=1.2.0",
+    "redis": "0.12.1",
+    "request": ">=2.53.0",
+    "safebox": ">=0.2.1",
+    "socket.io": ">=1.2.1",
+    "tmp": ">=0.0.24",
+    "uuid": "^3.0.0"
   },
   "optionalDependencies": {},
   "_engineSupported": true,
   "_npmVersion": "2.1.0",
   "_nodeVersion": "v0.12.0",
   "_defaultsLoaded": true,
-  "dist": {
-    
-  },
+  "dist": {},
   "_from": "SwarmCore"
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.